### PR TITLE
chore: public /api/healthz (no auth)

### DIFF
--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,0 +1,11 @@
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return new Response(
+    JSON.stringify({ ok: true, ts: new Date().toISOString() }),
+    { status: 200, headers: { 'content-type': 'application/json', 'cache-control': 'no-store' } }
+  );
+}
+
+

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,8 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 const isPublicRoute = createRouteMatcher([
+  "/api/healthz",
+  "/api/health",
   "/",
   "/favicon.ico",
   "/robots.txt",


### PR DESCRIPTION
Adds edge healthz endpoint and marks /api/healthz (and /api/health) public in Clerk middleware. Returns 200 without redirect for uptime checks.