### PR TITLE
codex 5.0.2 – Gate QA-bypass bak ENABLE_QA_BYPASS

### DIFF
--- a/docs/QA_BYPASS.md
+++ b/docs/QA_BYPASS.md
@@ -1,0 +1,50 @@
+# QA Bypass
+
+## Env
+- ENABLE_QA_BYPASS=1 (skrur på QA-bypass; sett 0 i prod når ferdig)
+- TEST_BYPASS_SECRET=<hemmelig> (brukes i header x-test-secret)
+- TEST_BYPASS_UPSERT=1 (valgfritt; oppretter QA-bruker automatisk)
+
+## Headers for QA-kall
+- x-test-secret: <hemmelig>
+- x-test-bypass: 1
+- x-test-role: platform-admin (utelat for å teste 403 på platform-API)
+- x-test-clerk-user-id: qa_admin
+- x-test-clerk-email: qa_admin@test.local
+- (valgfritt) x-test-org-id: <org-uuid>
+
+## Rask QA
+
+BASE="https://<prod-domene>"
+H1="x-test-secret: <hemmelig>"
+H2="x-test-bypass: 1"
+H3="x-test-role: platform-admin"
+H4="x-test-clerk-user-id: qa_admin"
+H5="x-test-clerk-email: qa_admin@test.local"
+
+# Healthz (200)
+# curl -i "$BASE/api/healthz"
+
+# Platform-API admin → 200
+# curl -i -H "$H1" -H "$H2" -H "$H3" -H "$H4" -H "$H5" "$BASE/api/platform/organizations?tech=react"
+
+# Platform-API uten rolle → 403
+# curl -i -H "$H1" -H "$H2" -H "$H4" -H "$H5" "$BASE/api/platform/organizations?tech=react"
+
+# Org-select (via orgnr) → 200 + Set-Cookie
+# curl -i -c /tmp/skx.jar -b /tmp/skx.jar \
+#   -H "$H1" -H "$H2" -H "$H3" -H "$H4" -H "$H5" \
+#   -H 'content-type: application/json' \
+#   -d '{"orgnr":"<9-sifret orgnr>"}' \
+#   "$BASE/api/org/select"
+
+# Homepage (QA) → 200
+# curl -i -c /tmp/skx.jar -b /tmp/skx.jar \
+#   -H "$H1" -H "$H2" -H "$H3" -H "$H4" -H "$H5" \
+#   -H 'content-type: application/json' \
+#   -d '{"url":"https://lexnord.test"}' \
+#   "$BASE/api/org/homepage"
+
+## Slå av QA i prod
+- Sett ENABLE_QA_BYPASS=0 og/eller roter TEST_BYPASS_SECRET.
+- Healthz beholdes public.

--- a/lib/auth-context.ts
+++ b/lib/auth-context.ts
@@ -13,8 +13,9 @@ export async function getAuthContext(req: Request): Promise<AuthContext | null> 
   const header = (name: string) => (hdrs.get ? hdrs.get(name) : hdrs.get(name));
 
   // QA-bypass før Clerk
+  const enableQa = process.env.ENABLE_QA_BYPASS === '1';
   const bypassSecret = (process.env.TEST_BYPASS_SECRET || process.env.TEST_SEED_SECRET || '').trim();
-  const hasBypass = (header('x-test-bypass') === '1') && !!bypassSecret && (header('x-test-secret') === bypassSecret);
+  const hasBypass = enableQa && (header('x-test-bypass') === '1') && !!bypassSecret && (header('x-test-secret') === bypassSecret);
   if (hasBypass) {
     const clerkUserId = header('x-test-clerk-user-id') || 'test_user';
     const email = header('x-test-clerk-email') || 'qa@test.local';

--- a/middleware.ts
+++ b/middleware.ts
@@ -53,9 +53,10 @@ export default function middleware(req: NextRequest) {
     return NextResponse.next({ headers: { 'Cache-Control': 'no-store' } });
   }
   // Early QA-bypass før Clerk (bruk TEST_BYPASS_SECRET eller fallback TEST_SEED_SECRET)
+  const enableQa = process.env.ENABLE_QA_BYPASS === '1';
   const bypassSecret = process.env.TEST_BYPASS_SECRET || process.env.TEST_SEED_SECRET;
   const hdr = req.headers.get('x-test-secret');
-  if (bypassSecret && hdr && hdr === bypassSecret) {
+  if (enableQa && bypassSecret && hdr && hdr === bypassSecret) {
     const requestHeaders = new Headers(req.headers);
     requestHeaders.set('x-test-bypass', '1');
     return NextResponse.next({ request: { headers: requestHeaders } });

--- a/server/authz.ts
+++ b/server/authz.ts
@@ -37,6 +37,8 @@ function qaHeaders(h?: any): Headers {
 }
 
 export function isQATestBypass(h?: any) {
+  const enabled = process.env.ENABLE_QA_BYPASS === '1';
+  if (!enabled) return false;
   const hh = qaHeaders(h);
   const sec = process.env.TEST_BYPASS_SECRET || process.env.TEST_SEED_SECRET || '';
   return !!sec && hh.get('x-test-bypass') === '1' && hh.get('x-test-secret') === sec;


### PR DESCRIPTION
- QA-bypass aktiveres kun når ENABLE_QA_BYPASS=1\n- middleware: tidlig bypass før Clerk bak flagg\n- auth-context: QA-session kun når flagg=1\n- guards: isQATestBypass() respekterer flagg\n- docs: docs/QA_BYPASS.md (env, headers, QA-kommandoer, avslag i prod)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional QA bypass toggle controlled by an environment flag; has no effect unless explicitly enabled.

* **Documentation**
  * Added a guide explaining how to enable, use, and disable the QA bypass, including required headers and sample requests for common scenarios (health checks, role-based access, org selection, homepage).
  * Notes included on safely turning the bypass off for production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->